### PR TITLE
add empty union example

### DIFF
--- a/conjure-python-core/src/test/resources/types/example-types.yml
+++ b/conjure-python-core/src/test/resources/types/example-types.yml
@@ -135,6 +135,8 @@ types:
           interface: integer
       EmptyObjectExample:
         fields: {}
+      EmptyUnionExample:
+        union: {}
       AliasAsMapKeyExample:
         fields:
           strings: map<StringAliasExample, ManyFieldExample>


### PR DESCRIPTION
An empty union passes the valid conjure check but does not generate valid python
